### PR TITLE
correcting URLs that allow students to view files in AMI on their browser window based on CSHL2023 AMI

### DIFF
--- a/_posts/0002-05-01-Alignment_Visualization.md
+++ b/_posts/0002-05-01-Alignment_Visualization.md
@@ -61,11 +61,11 @@ Make sure you select the appropriate reference genome build in IGV (top left cor
 #### AWS links to bam files
 **UHR hisat2 alignment:**
 
-http://**YOUR_DNS_NAME**/workspace/rnaseq/alignments/hisat2/UHR.bam
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/alignments/hisat2/UHR.bam
 
 **HBR hisat2 alignment:**
 
-http://**YOUR_DNS_NAME**/workspace/rnaseq/alignments/hisat2/HBR.bam
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/alignments/hisat2/HBR.bam
 
 
 You may wish to customize the track names as you load them in to keep them straight. Do this by right-clicking on the alignment track and choosing 'Rename Track'.
@@ -163,7 +163,7 @@ Assignment: Index your bam files from Practical Exercise 6 and visualize in IGV.
 
 * Hint: As before, it may be simplest to just index and visualize the combined/merged bam files HCC1395_normal.bam and HCC1395_tumor.bam.
 * If this works, you should have two BAM files that can be loaded into IGV from the following location on your cloud instance:
-  * http://**YOUR_DNS_NAME**/workspace/rnaseq/practice/alignments/hisat2/
+  * http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/practice/alignments/hisat2/
 
 **Questions**
 

--- a/_posts/0003-02-01-Expression.md
+++ b/_posts/0003-02-01-Expression.md
@@ -223,7 +223,7 @@ chmod +x Tutorial_ERCC_expression_tpm.R
 
 To view the resulting figures, navigate to the below URL replacing YOUR_IP_ADDRESS with your amazon instance IP address:
 
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/expression/htseq_counts/Tutorial_ERCC_expression.pdf
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/expression/stringtie/ref_only/Tutorial_ERCC_expression_tpm.pdf
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/expression/htseq_counts/Tutorial_ERCC_expression.pdf
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/expression/stringtie/ref_only/Tutorial_ERCC_expression_tpm.pdf
 
 Which expression estimation (read counts or TPM values) are better representing the known/expected ERCC concentrations?  Why?

--- a/_posts/0003-03-01-Differential_Expression.md
+++ b/_posts/0003-03-01-Differential_Expression.md
@@ -184,7 +184,7 @@ chmod +x Tutorial_ERCC_DE.R
 
 View the results here:
 
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/de/ballgown/ref_only/Tutorial_ERCC_DE.pdf
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/ballgown/ref_only/Tutorial_ERCC_DE.pdf
 
 ***
 
@@ -354,8 +354,8 @@ cat htseq_counts_edgeR_DE_gene_symbols.txt
 
 Alternatively you could view both lists in a web browser as you have done with other files. These two files should be here:
 
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/de/ballgown_DE_gene_symbols.txt
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/de/htseq_counts_edgeR_DE_gene_symbols.txt
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/ballgown_DE_gene_symbols.txt
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/htseq_counts_edgeR_DE_gene_symbols.txt
 
 ##### Example Venn Diagram (DE genes from StringTie/Ballgown vs HTSeq/EdgeR)
 

--- a/_posts/0003-04-01-DE_Visualization.md
+++ b/_posts/0003-04-01-DE_Visualization.md
@@ -21,9 +21,9 @@ cd $RNA_HOME/de/ballgown/ref_only
 R
 ```
 
-A separate R tutorial file has been provided below. Run the R commands detailed in the R script. All results are directed to pdf file(s). The output pdf files can be viewed in your browser at the following urls. Note, you must replace **YOUR_IP_ADDRESS** with your own amazon instance IP (e.g., 101.0.1.101)).
+A separate R tutorial file has been provided below. Run the R commands detailed in the R script. All results are directed to pdf file(s). The output pdf files can be viewed in your browser at the following urls. Note, you must replace **YOUR_PUBLIC_IPv4_ADDRESS** with your own amazon instance IP (e.g., 101.0.1.101)).
 
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/de/ballgown/ref_only/Tutorial_Part2_ballgown_output.pdf
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/ballgown/ref_only/Tutorial_Part2_ballgown_output.pdf
 
 First you'll need to load the libraries needed for this analysis and define a path for the output PDF to be written.
 
@@ -125,7 +125,7 @@ quit(save="no")
 
 Remember that you can view the output graphs of this step on your instance by navigating to this location in a web browser window:
 
-http://YOUR_IP_ADDRESS/workspace/rnaseq/de/ballgown/ref_only/Tutorial_Part2_ballgown_output.pdf
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/ballgown/ref_only/Tutorial_Part2_ballgown_output.pdf
 
 The above code can be found in a single R script located [here](https://github.com/griffithlab/rnabio.org/blob/master/assets/scripts/Tutorial_Part2_ballgown.R).
 
@@ -479,9 +479,9 @@ quit(save="no")
 
 Run the R commands detailed in the R script above. A R script containing all of the above code can be found [here](https://github.com/griffithlab/rnabio.org/blob/master/assets/scripts/Tutorial_Supplementary_R.R).
 
-The output file can be viewed in your browser at the following url. Note, you must replace **YOUR_IP_ADDRESS** with your own amazon instance IP (e.g., 101.0.1.101)).
+The output file can be viewed in your browser at the following url. Note, you must replace **YOUR_PUBLIC_IPv4_ADDRESS** with your own amazon instance IP (e.g., 101.0.1.101)).
 
-* http://**YOUR_IP_ADDRESS**/workspace/rnaseq/de/ballgown/ref_only/Tutorial_Part3_Supplementary_R_output.pdf
+* http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/ballgown/ref_only/Tutorial_Part3_Supplementary_R_output.pdf
 
 ***
 

--- a/_posts/0004-02-01-Alignment_Free_Kallisto.md
+++ b/_posts/0004-02-01-Alignment_Free_Kallisto.md
@@ -318,9 +318,9 @@ dev.off()
 quit(save="no")
 ```
 
-The output file can be viewed in your browser at the following url. Note, you must replace **YOUR_IP_ADDRESS** with your own amazon instance IP (e.g., 101.0.1.101)).
+The output file can be viewed in your browser at the following url. Note, you must replace **YOUR_PUBLIC_IPv4_ADDRESS** with your own amazon instance IP (e.g., 101.0.1.101)).
 
-http://**YOUR_IP_ADDRESS**/workspace/rnaseq/expression/Kallisto-StringTie-HTSeqCount_Comparisons.pdf
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/expression/Kallisto-StringTie-HTSeqCount_Comparisons.pdf
 
 A file copy of the above R code can be found [here](https://github.com/griffithlab/rnabio.org/blob/master/assets/scripts/Tutorial_comparisons.R).
 
@@ -481,9 +481,9 @@ cat sleuth_genes_with_de_transcripts.txt
 
 Alternatively you could view both lists in a web browser as you have done with other files. These three files should be here:
 
-http://YOUR_IP_ADDRESS/workspace/rnaseq/de/ballgown_DE_gene_symbols.txt
-http://YOUR_IP_ADDRESS/workspace/rnaseq/de/htseq_counts_edgeR_DE_gene_symbols.txt
-http://YOUR_IP_ADDRESS/workspace/rnaseq/de/sleuth_genes_with_de_transcripts.txt
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/ballgown_DE_gene_symbols.txt
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/htseq_counts_edgeR_DE_gene_symbols.txt
+http://**YOUR_PUBLIC_IPv4_ADDRESS**/rnaseq/de/sleuth_genes_with_de_transcripts.txt
 
 If this works you should see an overlap that looks something like this:
 


### PR DESCRIPTION
Current version of the tutorial has the students go to this URL to view the files-
http://YOUR_DNS_NAME/workspace/rnaseq/data/  

But based on the AMI setup for CSHL2023, they should instead go to-
http://YOUR_DNS_NAME/rnaseq/data/  
I have tried to find all the places in modules 1-4 where this happens and corrected it in this PR. 